### PR TITLE
Refactor main window setup for modularity

### DIFF
--- a/LEARNING/mainwindow.cpp
+++ b/LEARNING/mainwindow.cpp
@@ -1,160 +1,75 @@
 #include "mainwindow.h"
 
+#include <QAction>
+#include <QApplication>
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QFont>
+#include <QFontDatabase>
+#include <QGraphicsOpacityEffect>
+#include <QIcon>
+#include <QLineEdit>
+#include <QMenu>
+#include <QPalette>
+#include <QPropertyAnimation>
+#include <QScreen>
+#include <QSqlQuery>
+#include <QTimer>
+#include <QWheelEvent>
+#include <QtDebug>
+#include <QEasingCurve>
+
+#include "messagewindows.h"
+
+namespace {
+constexpr int kTypingSpeed = 150;
+constexpr int kMessageDuration = 1000;
+
+QIcon buildWindowIcon()
+{
+    QIcon icon;
+    icon.addFile(":/icon16.png", QSize(16, 16));
+    icon.addFile(":/icon24.png", QSize(24, 24));
+    icon.addFile(":/icon32.png", QSize(32, 32));
+    icon.addFile(":/icon48.png", QSize(48, 48));
+    icon.addFile(":/icon.png", QSize(64, 64));
+    return icon;
+}
+
+} // namespace
+
 MainWindow::MainWindow(QSqlDatabase * sql, QWidget *parent)
     : QMainWindow(parent)
     , ui(new Ui::MainWindow)
     , db(sql)
+    , label(nullptr)
+    , passwordInput(nullptr)
+    , winIcon(nullptr)
+    , myTimer(nullptr)
+    , introAnimationGroup(nullptr)
+    , windowAnimationGroup(nullptr)
     , m_mousePressed(false)
     , m_dragEnabled(false)
     , fixed(false)
     , dataReady(false)
+    , altL(nullptr)
+    , CtrlF(nullptr)
+    , roll(nullptr)
+    , menu(nullptr)
+    , input(nullptr)
+    , manmageWidget(nullptr)
 {
     ui->setupUi(this);
-    label = new AnimatedLabel("请输入主密码 ",this);
-    myTimer = new QTimer(this);
-    group = new QParallelAnimationGroup(this);
-    group2 = new QParallelAnimationGroup(this);
-    altL = new QShortcut(QKeySequence("Alt+L"),this);
-    connect(altL,&QShortcut::activated,this,&MainWindow::lockOper);
-    CtrlF = new QShortcut(QKeySequence("Ctrl+F"),this);
-    connect(CtrlF,&QShortcut::activated,this,&MainWindow::findShow);
-    winIcon = new QSystemTrayIcon(this);
-    menu = new QMenu(this);
-    roll = new RollWidget(db,this,this);
-    input = new newInput(db,roll,roll);
-    manmageWidget = new ManageWidget(db,roll,roll);
 
-    initial();
+    createCoreObjects();
+    setupShortcuts();
+    setupRollWidgets();
+    configureSystemTray();
+    initializeUi();
+    setupIntroAnimations();
+    setupWindowAnimation();
     databaseCheck();
-
-
 }
-
-void MainWindow::initial(){
-    // 设置窗口的背景色为黑色
-    roll->close();
-    QRect Window_rect = this->rect();
-    QPalette palette;
-    palette.setColor(QPalette::Background, Qt::black);
-    setPalette(palette);
-
-    // 设置窗口的透明度为半透明
-    setWindowOpacity(0.5);
-
-    // 设置窗口的大小
-    QSize windowSize = QSize(800, 600);
-    setFixedSize(800, 600);
-    QSize screenSize = qApp->screens().at(0)->size();
-    int x = (screenSize.width() - windowSize.width()) / 2;
-    int y = (screenSize.height() - windowSize.height()) / 2;
-    this->setGeometry(x, y, windowSize.width(), windowSize.height());
-
-    // 隐藏标题栏
-    setWindowFlags(Qt::FramelessWindowHint);
-
-    // anime动画效果
-    QPropertyAnimation * windowsAnimation = new QPropertyAnimation(this, "geometry");
-
-    QRect startRect = geometry();
-    QRect endRect = startRect.adjusted(width() / 4, height() / 4, -width() / 4, -height() / 4);
-    windowsAnimation->setStartValue(startRect);
-    windowsAnimation->setEndValue(endRect);
-    windowsAnimation->setDuration(1000);
-    windowsAnimation->setEasingCurve(QEasingCurve::InOutQuad);
-
-    connect(windowsAnimation, &QAbstractAnimation::stateChanged, this, [=](QAbstractAnimation::State newState, QAbstractAnimation::State) {
-        if (newState == QAbstractAnimation::Running) {
-            // 在动画开始时取消窗口的固定大小
-            setMinimumSize(0,0);
-            setMaximumSize(QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
-        } else if (newState == QAbstractAnimation::Stopped) {
-            // 在动画完成时将窗口大小设置为固定值
-            setFixedSize(400, 300);
-        }
-    });
-    group2->addAnimation(windowsAnimation);
-
-    // 创建后台图标 和菜单
-
-    menuInitial();
-
-    // 创建一个QLabel控件，显示“主密码”文字
-    int fontId = QFontDatabase::addApplicationFont(":/font.ttf");
-    if (fontId == -1) {
-            qDebug() << "Failed to load font";
-    }
-    QString fontFamily = QFontDatabase::applicationFontFamilies(fontId).at(0);
-
-    label->setFont(QFont(fontFamily, 32));
-    label->setAlignment(Qt::AlignCenter);  // 设置标签文本居中对齐
-    label->setStyleSheet("color: white;"); // 设置标签文本颜色为白色
-    label->setTextFormat(Qt::RichText);
-    QRect label_rect = label->rect();
-
-    position(&Window_rect,&label_rect,Type::Label);
-    label->setGeometry(label_rect);
-
-
-
-    // 动画效果
-
-    QObject::connect(myTimer, &QTimer::timeout, [=]() {
-        static bool isShow = true;
-        if (isShow) {
-            label->setText(label->text().replace(" ","|"));
-        } else {
-            label->setText(label->text().replace("|"," "));
-        }
-        isShow = !isShow;
-        label->update();
-    });
-    myTimer->start(800);
-
-    // anime动画效果
-
-    QPropertyAnimation *fontAnim = new QPropertyAnimation(label, "fontSize");
-    fontAnim->setDuration(1000);
-    fontAnim->setStartValue(32);
-    fontAnim->setEndValue(15);
-    fontAnim->setEasingCurve(QEasingCurve::OutQuad);
-
-
-    QPropertyAnimation *sizeAnim = new QPropertyAnimation(label, "geometry");
-    sizeAnim->setDuration(2000);
-    sizeAnim->setStartValue(label->geometry());
-    sizeAnim->setEndValue(QRect(0, 0, 400, 50));
-    sizeAnim->setEasingCurve(QEasingCurve::InOutQuad);
-
-
-    group->addAnimation(fontAnim);
-    group->addAnimation(sizeAnim);
-
-
-
-
-    // 创建一个QLineEdit控件，并将其添加到布局中
-    QLineEdit *lineEdit = new QLineEdit(this);
-    connect(lineEdit, &QLineEdit::returnPressed, this, &MainWindow::onReturnPressed);
-    QRect Edit_rect = lineEdit->rect();
-    position(&Window_rect,&Edit_rect,Type::Edit);
-    lineEdit->setGeometry(Edit_rect);
-
-
-
-    // anime动画效果
-    QGraphicsOpacityEffect *opacityEffect = new QGraphicsOpacityEffect(lineEdit);
-    lineEdit->setGraphicsEffect(opacityEffect);
-
-    QPropertyAnimation * editAnimation = new QPropertyAnimation(opacityEffect, "opacity");
-    editAnimation->setDuration(1000);
-    editAnimation->setStartValue(1.0);
-    editAnimation->setEndValue(0.0);
-
-    group->addAnimation(editAnimation);
-
-}
-
-
 
 MainWindow::~MainWindow()
 {
@@ -163,8 +78,354 @@ MainWindow::~MainWindow()
     delete ui;
 }
 
+void MainWindow::createCoreObjects()
+{
+    label = new AnimatedLabel(tr("请输入主密码 "), this);
+    passwordInput = new QLineEdit(this);
+    winIcon = new QSystemTrayIcon(this);
+    menu = new QMenu(this);
+    myTimer = new QTimer(this);
+    introAnimationGroup = new QParallelAnimationGroup(this);
+    windowAnimationGroup = new QParallelAnimationGroup(this);
 
-void MainWindow::position(QRect * mainWindow,QRect * tar,Type type){
+    roll = new RollWidget(db, this, this);
+    input = new newInput(db, roll, roll);
+    manmageWidget = new ManageWidget(db, roll, roll);
+}
+
+void MainWindow::setupShortcuts()
+{
+    altL = new QShortcut(QKeySequence(QStringLiteral("Alt+L")), this);
+    connect(altL, &QShortcut::activated, this, &MainWindow::lockOper);
+
+    CtrlF = new QShortcut(QKeySequence(QStringLiteral("Ctrl+F")), this);
+    connect(CtrlF, &QShortcut::activated, this, &MainWindow::findShow);
+}
+
+void MainWindow::setupRollWidgets()
+{
+    if (roll) {
+        roll->close();
+    }
+}
+
+void MainWindow::configureSystemTray()
+{
+    winIcon->setIcon(QIcon(":/icon.png"));
+    winIcon->show();
+    setWindowIcon(buildWindowIcon());
+
+    setupTrayActions();
+    connectTrayActions();
+    winIcon->setContextMenu(menu);
+}
+
+void MainWindow::setupTrayActions()
+{
+    actions.clear();
+    actions.reserve(7);
+    menu->clear();
+
+    actions.append(new QAction(QIcon(":/icons/1.png"), tr("添加数据"), this));
+    actions.append(new QAction(QIcon(":/icons/2.png"), tr("批量管理"), this));
+    actions.append(new QAction(this));
+    actions.append(new QAction(QIcon(":/icons/3.png"), tr("点击穿透"), this));
+    actions.append(new QAction(QIcon(":/icons/4.png"), tr("隐藏/显现窗口"), this));
+    actions.append(new QAction(this));
+    actions.append(new QAction(QIcon(":/icons/5.png"), tr("退出程序"), this));
+
+    actions[2]->setSeparator(true);
+    actions[5]->setSeparator(true);
+
+    for (QAction *action : actions) {
+        menu->addAction(action);
+    }
+
+    updateTrayAvailability();
+}
+
+void MainWindow::connectTrayActions()
+{
+    connect(actions[0], &QAction::triggered, input, &newInput::show);
+    connect(actions[1], &QAction::triggered, manmageWidget, &ManageWidget::show);
+    connect(actions[3], &QAction::triggered, this, &MainWindow::lockOper);
+    connect(actions[4], &QAction::triggered, this, &MainWindow::transHideShow);
+    connect(actions[6], &QAction::triggered, this, &MainWindow::requestQuit);
+}
+
+void MainWindow::initializeUi()
+{
+    configureWindowAppearance();
+    configureAnimatedLabel();
+    configurePasswordInput();
+    setupCursorBlinking();
+    updateTrayAvailability();
+}
+
+void MainWindow::configureWindowAppearance()
+{
+    QPalette palette;
+    palette.setColor(QPalette::Window, Qt::black);
+    setPalette(palette);
+
+    setWindowOpacity(0.5);
+
+    const QSize windowSize(800, 600);
+    setFixedSize(windowSize);
+
+    const QSize screenSize = qApp->screens().at(0)->size();
+    const int x = (screenSize.width() - windowSize.width()) / 2;
+    const int y = (screenSize.height() - windowSize.height()) / 2;
+    setGeometry(x, y, windowSize.width(), windowSize.height());
+
+    setWindowFlags(Qt::FramelessWindowHint);
+}
+
+void MainWindow::configureAnimatedLabel()
+{
+    const int fontId = QFontDatabase::addApplicationFont(":/font.ttf");
+    if (fontId == -1) {
+        qWarning() << "Failed to load font";
+    }
+
+    const QString fontFamily = QFontDatabase::applicationFontFamilies(fontId).value(0, font().family());
+    label->setFont(QFont(fontFamily, 32));
+    label->setAlignment(Qt::AlignCenter);
+    label->setStyleSheet(QStringLiteral("color: white;"));
+    label->setTextFormat(Qt::RichText);
+
+    QRect windowRect = rect();
+    QRect labelRect = label->rect();
+    position(&windowRect, &labelRect, Type::Label);
+    label->setGeometry(labelRect);
+}
+
+void MainWindow::configurePasswordInput()
+{
+    connect(passwordInput, &QLineEdit::returnPressed, this, &MainWindow::onReturnPressed);
+
+    QRect windowRect = rect();
+    QRect inputRect = passwordInput->rect();
+    position(&windowRect, &inputRect, Type::Edit);
+    passwordInput->setGeometry(inputRect);
+}
+
+void MainWindow::setupCursorBlinking()
+{
+    connect(myTimer, &QTimer::timeout, this, [this]() {
+        static bool isShow = true;
+        const QString from = isShow ? QStringLiteral(" ") : QStringLiteral("|");
+        const QString to = isShow ? QStringLiteral("|") : QStringLiteral(" ");
+        label->setText(label->text().replace(from, to));
+        isShow = !isShow;
+        label->update();
+    });
+
+    myTimer->start(800);
+}
+
+void MainWindow::setupIntroAnimations()
+{
+    auto *fontAnim = new QPropertyAnimation(label, QByteArrayLiteral("fontSize"));
+    fontAnim->setDuration(1000);
+    fontAnim->setStartValue(32);
+    fontAnim->setEndValue(15);
+    fontAnim->setEasingCurve(QEasingCurve::OutQuad);
+
+    auto *sizeAnim = new QPropertyAnimation(label, QByteArrayLiteral("geometry"));
+    sizeAnim->setDuration(2000);
+    sizeAnim->setStartValue(label->geometry());
+    sizeAnim->setEndValue(QRect(0, 0, 400, 50));
+    sizeAnim->setEasingCurve(QEasingCurve::InOutQuad);
+
+    auto *opacityEffect = new QGraphicsOpacityEffect(passwordInput);
+    passwordInput->setGraphicsEffect(opacityEffect);
+
+    auto *editAnimation = new QPropertyAnimation(opacityEffect, QByteArrayLiteral("opacity"));
+    editAnimation->setDuration(1000);
+    editAnimation->setStartValue(1.0);
+    editAnimation->setEndValue(0.0);
+
+    introAnimationGroup->addAnimation(fontAnim);
+    introAnimationGroup->addAnimation(sizeAnim);
+    introAnimationGroup->addAnimation(editAnimation);
+}
+
+void MainWindow::setupWindowAnimation()
+{
+    auto *windowsAnimation = new QPropertyAnimation(this, QByteArrayLiteral("geometry"));
+    const QRect startRect = geometry();
+    const QRect endRect = startRect.adjusted(width() / 4, height() / 4, -width() / 4, -height() / 4);
+    windowsAnimation->setStartValue(startRect);
+    windowsAnimation->setEndValue(endRect);
+    windowsAnimation->setDuration(1000);
+    windowsAnimation->setEasingCurve(QEasingCurve::InOutQuad);
+
+    connect(windowsAnimation, &QAbstractAnimation::stateChanged, this,
+            [this](QAbstractAnimation::State newState, QAbstractAnimation::State) {
+                if (newState == QAbstractAnimation::Running) {
+                    setMinimumSize(0, 0);
+                    setMaximumSize(QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX));
+                } else if (newState == QAbstractAnimation::Stopped) {
+                    setFixedSize(400, 300);
+                }
+            });
+
+    windowAnimationGroup->addAnimation(windowsAnimation);
+}
+
+void MainWindow::updateTrayAvailability()
+{
+    const bool enabled = m_dragEnabled;
+    if (actions.size() >= 4) {
+        actions[0]->setEnabled(enabled);
+        actions[1]->setEnabled(enabled);
+        actions[3]->setEnabled(enabled);
+    }
+}
+
+void MainWindow::showTypedMessage(const QString &text, int speed, bool append)
+{
+    if (append) {
+        appendWorld(text, label, speed);
+    } else {
+        label->setText(QStringLiteral("|"));
+        setWorld(text, label, speed);
+    }
+}
+
+void MainWindow::stopCursorBlinking()
+{
+    if (myTimer->isActive()) {
+        myTimer->stop();
+    }
+    label->setText(label->text().replace(QStringLiteral("|"), QStringLiteral(" ")));
+}
+
+void MainWindow::runLater(int delayMs, const std::function<void()> &task)
+{
+    QTimer::singleShot(delayMs, this, [task]() {
+        if (task) {
+            task();
+        }
+    });
+}
+
+void MainWindow::setWindowInteractivity(bool clickThroughEnabled)
+{
+    setAttribute(Qt::WA_TransparentForMouseEvents, clickThroughEnabled);
+
+    Qt::WindowFlags flags = Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint;
+    if (clickThroughEnabled) {
+        flags |= Qt::Tool;
+    }
+    setWindowFlags(flags);
+    show();
+}
+
+void MainWindow::toggleRollVisibility(bool visible)
+{
+    if (!roll) {
+        return;
+    }
+
+    if (visible) {
+        roll->showOnly();
+    } else {
+        roll->hide();
+    }
+}
+
+void MainWindow::SuccessOperation()
+{
+    QSqlQuery query;
+    query.exec(QStringLiteral("SELECT * FROM user"));
+
+    QString username;
+    if (query.next()) {
+        username = query.value(QStringLiteral("username")).toString();
+    } else {
+        qWarning() << "No records found";
+    }
+
+    runLater(1500, [this, username]() {
+        introAnimationGroup->start(QAbstractAnimation::DeleteWhenStopped);
+        passwordInput->setEnabled(false);
+        stopCursorBlinking();
+
+        label->setText(label->text().append(QStringLiteral(" ")));
+        runLater(2000, [this, username]() {
+            appendWorld(username, label, kTypingSpeed);
+            windowAnimationGroup->start(QAbstractAnimation::DeleteWhenStopped);
+            m_dragEnabled = true;
+            runLater(2000, [this]() {
+                roll->setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
+                roll->show();
+                setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
+                installEventFilter(this);
+                show();
+                updateTrayAvailability();
+            });
+        });
+    });
+}
+
+void MainWindow::databaseCheck()
+{
+    QSqlQuery query;
+    query.prepare(QStringLiteral("SELECT name FROM sqlite_master WHERE type='table' AND name='user'"));
+    if (query.exec() && query.next()) {
+        dataReady = true;
+        const QString tableName = query.value(0).toString();
+        qDebug() << "Table '" << tableName << "' exists in database.";
+    } else {
+        showTypedMessage(tr("请输入您的用户名"), kTypingSpeed, false);
+    }
+}
+
+void MainWindow::setWorld(const QString & str,QLabel * tar,int speed)
+{
+    QTimer* timer = new QTimer(this);
+    connect(timer, &QTimer::timeout, [=]() {
+        const int index = tar->text().length() - 1;
+        QString label_text = tar->text();
+        if (index >= str.length()) {
+            timer->stop();
+            timer->deleteLater();
+            return;
+        }
+        label_text[index] = str[index];
+        label_text.append('|');
+        tar->setText(label_text);
+    });
+    timer->start(speed);
+}
+
+void MainWindow::appendWorld(const QString & str,QLabel * tar,int speed)
+{
+    QTimer* timer = new QTimer(this);
+    const int startIndex = tar->text().length();
+    int index = 0;
+    connect(timer, &QTimer::timeout, [=]() mutable {
+        QString label_text = tar->text();
+        if (index >= str.length()) {
+            timer->stop();
+            timer->deleteLater();
+            QString labelText = label->text();
+            labelText.chop(1);
+            label->setText(labelText);
+            return;
+        }
+        label_text[startIndex + index - 1] = str[index];
+        label_text.append('|');
+        tar->setText(label_text);
+        ++index;
+    });
+    timer->start(speed);
+}
+
+void MainWindow::position(QRect * mainWindow,QRect * tar,Type type)
+{
     if(type == Type::Label){
         tar->setWidth(mainWindow->width());
         tar->setTop(mainWindow->height()*0.2);
@@ -177,286 +438,149 @@ void MainWindow::position(QRect * mainWindow,QRect * tar,Type type){
     }
 }
 
-void MainWindow::SuccessOperation(QLineEdit *lineEdit){
-
-    //为数据库留空间
-    QSqlQuery query;
-    query.exec("SELECT * FROM user");
-    QString username = "";
-    if (query.next()) {
-        username = query.value("username").toString();
-    } else {
-        qWarning() << "No records found";
+void MainWindow::onReturnPressed()
+{
+    if (passwordInput->text().isEmpty()) {
+        return;
     }
 
-
-    QTimer::singleShot(1500, this, [=](){
-        //启动变形动画
-        group->start(QAbstractAnimation::DeleteWhenStopped);
-        lineEdit->setEnabled(false);
-        //停止光标动画
-        myTimer->stop();
-        label->setText(label->text().replace("|"," "));
-        label->setText(label->text().append(" "));
-        QTimer::singleShot(2000, this, [=](){
-            appendWorld(username,label,150);
-            group2->start(QAbstractAnimation::DeleteWhenStopped);
-            //设置flag 为true 进入变形后的窗口设置（允许窗口拖动、滚轮生效、加载数据）
-            m_dragEnabled = true;
-            QTimer::singleShot(2000, this, [=](){
-
-                roll->setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
-                roll->show();
-                setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
-                this->installEventFilter(this);
-                show();
-                menuStatusChange();
-            });
-        });
-    });
-}
-
-void MainWindow::onReturnPressed(){
-    QLineEdit *lineEdit = qobject_cast<QLineEdit *>(sender()); // 获取信号的发送者
-    if(lineEdit->text().isEmpty()) return;
     if(!dataReady){
         static QString username = "";
         static QString password = "";
-        if(username == ""){
-            username = lineEdit->text();
-            QString world = "请输入您的密码";
-            label->setText("|");
-            setWorld(world,label,150);
+        if(username.isEmpty()){
+            username = passwordInput->text();
+            showTypedMessage(tr("请输入您的密码"), kTypingSpeed, false);
         }else{
-            password = lineEdit->text();
+            password = passwordInput->text();
             QSqlQuery query;
-            query.exec("CREATE DATABASE IF NOT EXISTS main");
-            query.exec("CREATE TABLE IF NOT EXISTS user ("
+            query.exec(QStringLiteral("CREATE DATABASE IF NOT EXISTS main"));
+            query.exec(QStringLiteral("CREATE TABLE IF NOT EXISTS user ("
                        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
                        "username TEXT,"
                        "password TEXT"
-                       ")");
-            query.prepare("INSERT INTO \"main\".\"user\"(\"id\", \"username\", \"password\") VALUES (1, '" + username + "', '" + password + "');");
+                       ")"));
+            query.prepare(QStringLiteral("INSERT INTO \"main\".\"user\"(\"id\", \"username\", \"password\") VALUES (1, :username, :password);"));
+            query.bindValue(":username", username);
+            query.bindValue(":password", password);
 
             QSqlQuery query2;
-            query2.exec("CREATE TABLE form ("
+            query2.exec(QStringLiteral("CREATE TABLE form ("
                        "id INTEGER PRIMARY KEY AUTOINCREMENT,"
                        "user TEXT,"
                        "password TEXT,"
                        "position TEXT,"
                        "plus TEXT"
-                       ")");
+                       ")"));
 
-            QString world = "初始化完成";
+            QString world = tr("初始化完成");
             if(!query.exec()){
-                world = "初始化失败，请重试";
-                username = "";
-                password = "";
+                world = tr("初始化失败，请重试");
+                username.clear();
+                password.clear();
             }else{
                 dataReady = true;
             }
-            label->setText("|");
-            setWorld(world,label,150);
-            //注册后直接登录 设置数据库状态为ready
-            QTimer::singleShot(2000, this, [=](){
-                QString world = "Welcome";
-                label->setText("|");
-                setWorld(world,label,150);
-                SuccessOperation(lineEdit);
+            showTypedMessage(world, kTypingSpeed, false);
+            runLater(2000, [this]() {
+                showTypedMessage(QStringLiteral("Welcome"), kTypingSpeed, false);
+                SuccessOperation();
             });
         }
-        lineEdit->clear();
+        passwordInput->clear();
         return;
     }
 
-
-    //为数据库留空间
     QSqlQuery query;
-    query.exec("SELECT * FROM main.user");
-    if (query.next()) {
-        QString password = query.value("password").toString();
-    } else {
-        qWarning() << "No records found";
-    }
-
-    QString password = query.value("password").toString();
-
-    QString text = lineEdit->text(); // 获取用户输入的文本信息
-    if(text == password){
-        //welcome动画部分
-        QString world = "Welcome";
-        label->setText("|");
-        setWorld(world,label,150);
-
-        // 输入正确的处理
-        SuccessOperation(lineEdit);
+    query.exec(QStringLiteral("SELECT * FROM main.user"));
+    QString password = query.next() ? query.value(QStringLiteral("password")).toString() : QString();
+    if(password == passwordInput->text()){
+        showTypedMessage(QStringLiteral("Welcome"), kTypingSpeed, false);
+        SuccessOperation();
     }else{
-        QString world = "密码错误";
-        label->setText("|");
-        setWorld(world,label,150);
+        showTypedMessage(tr("密码错误"), kTypingSpeed, false);
     }
-    lineEdit->clear();
+    passwordInput->clear();
 }
 
-// 从只有" "的字符串开始添加
-void MainWindow::setWorld(const QString & str,QLabel * tar,int speed){
-    QTimer* timer = new QTimer(this);
-    connect(timer, &QTimer::timeout, [=]() {
-        int index = tar->text().length() - 1;
-        QString label_text = tar->text();
-        if (index >= str.length()) {
-            timer->stop();
-            return;
-        }
-        label_text[index] = str[index];
-        label_text.append('|');
-        tar->setText(label_text);
-    });
-    timer->start(speed);
-}
-
-// 为已经存在字符串的添加
-void MainWindow::appendWorld(const QString & str,QLabel * tar,int speed){
-    QTimer* timer = new QTimer(this);
-    //计算全部的字符长度 通过 全部-当前确定剩余多少个
-    int startIndex = tar->text().length();
-    int index = 0;
-    connect(timer, &QTimer::timeout, [=]() mutable {
-        //label存储的是当前的内容
-        QString label_text = tar->text();
-        if (index >= str.length()) {
-            timer->stop();
-            //处理末尾的字符
-            QString labelText = label->text();
-            labelText.chop(1);
-            label->setText(labelText);
-            return;
-        }
-        label_text[startIndex + index - 1] = str[index];
-        label_text.append('|');
-        tar->setText(label_text);
-        index ++;
-    });
-    timer->start(speed);
-}
-
-
-void MainWindow::databaseCheck(){
-    QSqlQuery query;
-    query.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='user'");
-    if (query.exec() && query.next()) {
-        //数据库准备就绪
-        dataReady = true;
-        QString tableName = query.value(0).toString();
-        qDebug() << "Table '" << tableName << "' exists in database.";
-    } else {
-        QString world = "请输入您的用户名";
-        label->setText("|");
-        setWorld(world,label,150);
+void MainWindow::lockOper()
+{
+    if(!m_dragEnabled) {
+        return;
     }
+
+    fixed = !fixed;
+    setWindowInteractivity(fixed);
+
+    const QString message = fixed ? tr("点击穿透已启用") : tr("点击穿透已关闭");
+    auto *ms = new MessageWindows(message, kMessageDuration);
+    ms->messageShow();
 }
 
-
-void MainWindow::lockOper(){
-    if(!m_dragEnabled) return;
-
-    if(fixed){
-        setAttribute(Qt::WA_TransparentForMouseEvents, false);
-        setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
-        fixed = false;
-        MessageWindows * ms = new MessageWindows("点击穿透已关闭",1000);
-        ms->messageShow();
-    }else{
-
-        setAttribute(Qt::WA_TransparentForMouseEvents, true);
-        setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::Tool);
-        fixed = true;
-        MessageWindows * ms = new MessageWindows("点击穿透已启用",1000);
-        ms->messageShow();
-    }
-    show();
-}
-
-void MainWindow::wheelEvent(QWheelEvent *event){
+void MainWindow::wheelEvent(QWheelEvent *event)
+{
     if(m_dragEnabled){
         QApplication::sendEvent(roll,event);
     }
 }
 
-void MainWindow::menuInitial(){
-    // 图标设置
-    QIcon icon (":/icon.png");
-    winIcon->setIcon(icon);
-    winIcon->show();
-    QIcon wIcon;
-    wIcon.addFile(":/icon16.png",QSize(16,16));
-    wIcon.addFile(":/icon24.png",QSize(24,24));
-    wIcon.addFile(":/icon32.png",QSize(32,32));
-    wIcon.addFile(":/icon48.png",QSize(48,48));
-    wIcon.addFile(":/icon.png",QSize(64,64));
-    setWindowIcon(wIcon);
-
-
-    // 窗口菜单设置
-    actions.append(new QAction(QIcon(":/icons/1.png"),"添加数据",this));
-    actions.append(new QAction(QIcon(":/icons/2.png"),"批量管理",this));
-    actions.append(new QAction());
-    actions.append(new QAction(QIcon(":/icons/3.png"),"点击穿透",this));
-    actions.append(new QAction(QIcon(":/icons/4.png"),"隐藏/显现窗口",this));
-    actions.append(new QAction());
-    actions.append(new QAction(QIcon(":/icons/5.png"),"退出程序",this));
-    actions[0]->setEnabled(false);
-    actions[1]->setEnabled(false);
-    actions[3]->setEnabled(false);
-    actions[2]->setSeparator(true);
-    actions[5]->setSeparator(true);
-
-    connect(actions[0],&QAction::triggered,input,&newInput::show);
-    connect(actions[1],&QAction::triggered,manmageWidget,&ManageWidget::show);
-    connect(actions[3],&QAction::triggered,this,&MainWindow::lockOper);
-    connect(actions[4],&QAction::triggered,this,&MainWindow::transHideShow);
-    connect(actions[6],&QAction::triggered,this,&MainWindow::close);
-
-
-    auto it = actions.begin();
-    while(it != actions.end()){
-        menu->addAction((*it));
-        ++it;
-    }
-
-    winIcon->setContextMenu(menu);
-}
-
-void MainWindow::menuStatusChange(){
-    if(m_dragEnabled){
-        actions[0]->setEnabled(true);
-        actions[1]->setEnabled(true);
-        actions[3]->setEnabled(true);
-    }else{
-        actions[0]->setEnabled(false);
-        actions[1]->setEnabled(false);
-        actions[3]->setEnabled(false);
-    }
-}
-
-void MainWindow::close(){
+void MainWindow::requestQuit()
+{
     QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
     QTimer::singleShot(0, qApp, &QCoreApplication::quit);
 }
 
-void MainWindow::transHideShow(){
-    if(this->isHidden()){
-        show();
-        if(m_dragEnabled)
-            roll->showOnly();
-    }else{
-        hide();
-        if(m_dragEnabled)
-            roll->hide();
+void MainWindow::transHideShow()
+{
+    const bool currentlyHidden = isHidden();
+    setVisible(currentlyHidden);
+    if(m_dragEnabled){
+        toggleRollVisibility(currentlyHidden);
     }
 }
 
-void MainWindow::findShow(){
-    if(m_dragEnabled)
+void MainWindow::findShow()
+{
+    if(m_dragEnabled){
         roll->showFind();
+    }
+}
+
+void MainWindow::mousePressEvent(QMouseEvent *event)
+{
+    if(fixed){
+        return;
+    }
+    if (event->button() == Qt::LeftButton) {
+        m_mousePressed = true;
+        m_lastMousePos = event->globalPos();
+    }
+}
+
+void MainWindow::mouseReleaseEvent(QMouseEvent *event)
+{
+    if(fixed){
+        return;
+    }
+    if (event->button() == Qt::LeftButton) {
+        m_mousePressed = false;
+    }
+}
+
+void MainWindow::mouseMoveEvent(QMouseEvent *event)
+{
+    if(fixed){
+        return;
+    }
+    if (m_mousePressed && m_dragEnabled) {
+        QPoint delta = event->globalPos() - m_lastMousePos;
+        move(pos() + delta);
+        roll->move(roll->pos() + delta);
+        m_lastMousePos = event->globalPos();
+    }
+}
+
+void MainWindow::closeEvent(QCloseEvent * event)
+{
+    event->ignore();
+    transHideShow();
 }

--- a/LEARNING/mainwindow.h
+++ b/LEARNING/mainwindow.h
@@ -1,41 +1,35 @@
 #ifndef MAINWINDOW_H
 #define MAINWINDOW_H
 
-#include <QMainWindow>
-#include <QRect>
-#include <QLabel>
-#include <QParallelAnimationGroup>
-#include "animatedlabel.h"
-#include <QMouseEvent>
-#include <QEvent>
-#include <QDebug>
-#include <QSqlDatabase>
-#include <QSqlQuery>
-#include <QSqlError>
-#include <QFileInfo>
-#include <QLineEdit>
-#include "ui_mainwindow.h"
-#include <QVBoxLayout>
-#include <QResizeEvent>
-#include <QPropertyAnimation>
-#include <QGraphicsOpacityEffect>
-#include <QTimer>
-#include <QEasingCurve>
 #include <QAbstractAnimation>
-#include <QSize>
-#include <QScreen>
-#include <Windows.h>
-#include <WinUser.h>
-#include <QSqlQueryModel>
-#include <QSqlRecord>
-#include "rollwidget.h"
-#include <QShortcut>
-#include <QKeySequence>
-#include <QSystemTrayIcon>
-#include <QMenu>
+#include <QCloseEvent>
 #include <QEvent>
-#include "newinput.h"
+#include <QLabel>
+#include <QKeySequence>
+#include <QMainWindow>
+#include <QMenu>
+#include <QMouseEvent>
+#include <QParallelAnimationGroup>
+#include <QPoint>
+#include <QRect>
+#include <QShortcut>
+#include <QSize>
+#include <QSystemTrayIcon>
+#include <QTimer>
+#include <QWheelEvent>
+#include <QtSql/QSqlDatabase>
+#include <QVector>
+#include <functional>
+
+#include "animatedlabel.h"
 #include "managewidget.h"
+#include "newinput.h"
+#include "rollwidget.h"
+#include "ui_mainwindow.h"
+
+QT_FORWARD_DECLARE_CLASS(QLineEdit)
+QT_FORWARD_DECLARE_CLASS(QMenu)
+QT_FORWARD_DECLARE_CLASS(QSqlQuery)
 
 
 QT_BEGIN_NAMESPACE
@@ -54,42 +48,11 @@ public:
     MainWindow(QSqlDatabase * sql = nullptr ,QWidget *parent = nullptr);
     ~MainWindow();
 protected:
-    void closeEvent(QCloseEvent * event) override{
-        event->ignore();
-        transHideShow();
-    }
+    void closeEvent(QCloseEvent * event) override;
     void wheelEvent(QWheelEvent *event) override;
-    void mousePressEvent(QMouseEvent *event) override
-    {
-        if(fixed)
-            return;
-        if (event->button() == Qt::LeftButton) {
-            m_mousePressed = true;
-            m_lastMousePos = event->globalPos();
-        }
-    }
-
-    void mouseReleaseEvent(QMouseEvent *event) override
-    {
-
-        if(fixed)
-            return;
-        if (event->button() == Qt::LeftButton) {
-            m_mousePressed = false;
-        }
-    }
-
-    void mouseMoveEvent(QMouseEvent *event) override
-    {
-        if(fixed)
-            return;
-        if (m_mousePressed && m_dragEnabled) {
-            QPoint delta = event->globalPos() - m_lastMousePos;
-            move(pos() + delta);
-            roll->move(roll->pos() + delta);
-            m_lastMousePos = event->globalPos();
-        }
-    }
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
 //    bool nativeEvent(const QByteArray &eventType, void *message, long *result) override;
 
@@ -98,10 +61,11 @@ private:
     Ui::MainWindow *ui;
     QSqlDatabase * db;
     AnimatedLabel * label;
+    QLineEdit * passwordInput;
     QSystemTrayIcon * winIcon;
     QTimer *myTimer;
-    QParallelAnimationGroup *group ;
-    QParallelAnimationGroup *group2;
+    QParallelAnimationGroup *introAnimationGroup;
+    QParallelAnimationGroup *windowAnimationGroup;
     bool m_mousePressed;
     bool m_dragEnabled;
     bool fixed;
@@ -117,15 +81,29 @@ private:
 
 
 
-    void SuccessOperation(QLineEdit *lineEdit);
+    void SuccessOperation();
     void databaseCheck();
-    void initial();
     void setWorld(const QString & str,QLabel * tar,int speed);
     void appendWorld(const QString & str,QLabel * tar,int speed);
-    void appear();
-    void disappear();
-    void menuInitial();
-    void menuStatusChange();
+    void createCoreObjects();
+    void setupShortcuts();
+    void initializeUi();
+    void configureWindowAppearance();
+    void configureAnimatedLabel();
+    void configurePasswordInput();
+    void setupCursorBlinking();
+    void setupIntroAnimations();
+    void setupWindowAnimation();
+    void configureSystemTray();
+    void setupTrayActions();
+    void connectTrayActions();
+    void updateTrayAvailability();
+    void setupRollWidgets();
+    void showTypedMessage(const QString &text, int speed = 150, bool append = false);
+    void stopCursorBlinking();
+    void runLater(int delayMs, const std::function<void()> &task);
+    void setWindowInteractivity(bool clickThroughEnabled);
+    void toggleRollVisibility(bool visible);
 
 public slots:
 
@@ -133,7 +111,7 @@ public slots:
 private slots:
     void position(QRect * mainWindow,QRect * tar,Type type);
     void onReturnPressed();
-    void close();
+    void requestQuit();
     void transHideShow();
     void findShow();
 


### PR DESCRIPTION
## Summary
- reorganized MainWindow construction into focused helper routines for window appearance, tray setup, animations, and widget initialization
- centralized login flow messaging and animation triggers to reduce order-sensitive logic and improve readability
- added utility helpers for delayed tasks and click-through toggling to make future visual adjustments safer

## Testing
- not run (Qt tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d67b95d1b48333bdf41408609ae905